### PR TITLE
Updated scripts to account for conflicting nvm versions

### DIFF
--- a/scripts/add
+++ b/scripts/add
@@ -1,4 +1,6 @@
 #!/bin/bash
+unset PREFIX
+unset npm_config_prefix
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -2,6 +2,7 @@
 set -e
 unset PREFIX
 unset npm_config_prefix
+export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
-export NVM_DIR="$HOME/.nvm"
+unset PREFIX
+unset npm_config_prefix
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 

--- a/scripts/release
+++ b/scripts/release
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+unset PREFIX
+unset npm_config_prefix
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion


### PR DESCRIPTION
Before this, these scripts would give the following error:

```
nvm is not compatible with the "PREFIX" environment variable: currently set to "/Users/jackson/.nvm/versions/node/v15.2.1"
```