### PR TITLE
Update SolidOS README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,10 @@ In the above diagram, SolidOS is deployed on the [Node Solid Server (NSS)](https
 
 ### SolidOS deeper technical topics
 
-For further details about each GitHub repository, please visit them via the links above.
+For further details about each GitHub repository, please visit them via the links above for `Documentation`.
 
 We collect SolidOS code good practices and know how in [SolidOS documentation pages](https://github.com/solid/solidos/tree/main/documentation).
+
 [SolidOS FAQs](https://github.com/solid/solidos/wiki/FAQs) part of the [SolidOS developer guide](https://github.com/solid/solidos/wiki) also contains some Q&A and technical troubleshooting infos.
 
 


### PR DESCRIPTION
I'm not so happy with the access to Documentation in the different repos.
This came because I was looking for some and also the forum discussion https://forum.solidproject.org/t/is-rdf-hard/5056?u=bourgeoa introducing a Developer Relations question.
May be we could consider either :
- a wiki page SolidOS documentation
- or in github.com/dolid/solidos/Documentation

with links to all types of documentation :
- SolidOS general presentation (talks, videos)
- API (rdflib, solid-ui)
- technical (style, developers recommendations)
- data models and ontologies
- demos