### PR TITLE
reusable workflow publish-release.yml

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -5,9 +5,9 @@ on:
     inputs:
       node_version:
         description: Node.js version to use
-        type: string
+        type: number
         required: false
-        default: '22'
+        default: 22
 
 jobs:
   prerelease-check:


### PR DESCRIPTION
This is to be used in SolidOS packages to replace `npm-publish-build` (hash publish on any push)
with a `npm version prerelease` only. Last prerelease is tagged with `dev`
This allow developers to publish a specific prerelease package for their local development.

usage example :

```yml
npm-publish-dev:
  needs: build
  uses: SolidOS/solidos/.github/workflows/publish-prerelease.yml@main
  with:
    node_version: 22
``` 