### PR TITLE
Adjust scripts to match (pivot)

### DIFF
--- a/scripts/reset
+++ b/scripts/reset
@@ -19,7 +19,8 @@ declare -a packages=(
   "solid-ui"
   "pane-registry"
   "solid-logic"
-  "rdflib")
+  "rdflib"
+  "pivot")
 
 # Clone and npm install dependent packages
 for package in "${packages[@]}"
@@ -37,6 +38,9 @@ do
   pushd workspaces/$package
   nvm use --delete-prefix
   npm run build
+  if [[ "$package" == "rdflib" ]]; then
+    npm run build:types
+  fi
   popd
 done
 

--- a/scripts/switch-branch
+++ b/scripts/switch-branch
@@ -12,7 +12,6 @@ FOLDER=$1
 echo ">>>>> SETTING UP PROJECT WITH NEW BRANCH $1"
 mkdir -p workspaces
 
-<<<<<<< HEAD
 # Determine packages from the current workspaces directory contents
 declare -a packages=()
 for dir in workspaces/*; do
@@ -27,17 +26,6 @@ if [ ${#packages[@]} -eq 0 ]; then
 fi
 
 rm -rf workspaces/*
-=======
-declare -a packages=(
-  "solid-logic"
-  "pane-registry"
-  "solid-ui"
-  "profile-pane"
-  "solid-panes"
-  "mashlib"
-  "css-mashlib"
-  "pivot")
->>>>>>> 124d217 (add pivot & make reset and watch match)
 
 # Clone and npm install dependent packages
 for package in "${packages[@]}"
@@ -58,22 +46,6 @@ do
   popd
 done
 
-<<<<<<< HEAD
-=======
-# Build dependent packages, ensuring each is in proper Node environment via nvm
-for package in "${packages[@]}"
-do
-  echo ""
-  echo "# Building $package"
-  pushd workspaces/$package
-  nvm use --delete-prefix
-  npm run build
-  if [[ "$package" == "rdflib" ]]; then
-    npm run build:types
-  fi
-  popd
-done
->>>>>>> 124d217 (add pivot & make reset and watch match)
 
 for x in workspaces/* ; do ( echo "###### " $x; cd $x; git status)  done
 

--- a/scripts/switch-branch
+++ b/scripts/switch-branch
@@ -12,6 +12,7 @@ FOLDER=$1
 echo ">>>>> SETTING UP PROJECT WITH NEW BRANCH $1"
 mkdir -p workspaces
 
+<<<<<<< HEAD
 # Determine packages from the current workspaces directory contents
 declare -a packages=()
 for dir in workspaces/*; do
@@ -26,6 +27,17 @@ if [ ${#packages[@]} -eq 0 ]; then
 fi
 
 rm -rf workspaces/*
+=======
+declare -a packages=(
+  "solid-logic"
+  "pane-registry"
+  "solid-ui"
+  "profile-pane"
+  "solid-panes"
+  "mashlib"
+  "css-mashlib"
+  "pivot")
+>>>>>>> 124d217 (add pivot & make reset and watch match)
 
 # Clone and npm install dependent packages
 for package in "${packages[@]}"
@@ -46,6 +58,22 @@ do
   popd
 done
 
+<<<<<<< HEAD
+=======
+# Build dependent packages, ensuring each is in proper Node environment via nvm
+for package in "${packages[@]}"
+do
+  echo ""
+  echo "# Building $package"
+  pushd workspaces/$package
+  nvm use --delete-prefix
+  npm run build
+  if [[ "$package" == "rdflib" ]]; then
+    npm run build:types
+  fi
+  popd
+done
+>>>>>>> 124d217 (add pivot & make reset and watch match)
 
 for x in workspaces/* ; do ( echo "###### " $x; cd $x; git status)  done
 

--- a/scripts/watch-pivot
+++ b/scripts/watch-pivot
@@ -13,9 +13,8 @@ nvm use --delete-prefix
 npx lerna bootstrap --force-local
 
 declare -a packageNames=(
+  "solid-logic"
   "solid-ui"
-  "contacts-pane"
-  "profile-pane"
   "solid-panes"
   "mashlib"
   "pivot"
@@ -31,17 +30,13 @@ trap cleanup INT TERM EXIT
 
 for package in "${packageNames[@]}"; do
   case "$package" in
+    "solid-logic")
+      prestart="npm run build"
+      start="npm run watch"
+      ;;
     "solid-ui")
       prestart="npm run build"
       start='npx concurrently -k -n npm,styles "npm:watch-npm" "npm:watch-styles"'
-      ;;
-    "contacts-pane")
-      prestart="npm run build-dist"
-      start="npm run watch-dist"
-      ;;
-    "profile-pane")
-      prestart="npm run build-dist && npm run build-js"
-      start='npx concurrently -k -n babel,webpack "npm:watch-js" "npm:watch-dist"'
       ;;
     "solid-panes")
       prestart="npm run build-version"

--- a/scripts/watch-pivot
+++ b/scripts/watch-pivot
@@ -44,7 +44,7 @@ for package in "${packageNames[@]}"; do
       ;;
     "mashlib")
       prestart="npm run build-version"
-      start="npm run watch"
+      start="npm run watch:workspace"
       ;;
     "pivot")
       prestart=""


### PR DESCRIPTION
When attempting to run I received a few issues and wanted to update the scripts to avoid others having the same problems.
Pivot was apart of the watch-pivot script but wasn't added during reset (setup - which calls reset). Also there were repos added to the watch-pivot that are not added during setup. I removed them.

This is just a draft as I wasn't sure if we wanted to add in profile-pane and contacts-pane into the reset instead of removing them from the watch-pivot script?

Also solid-logic needs the types for rdflib in particular this file lib/index.d.ts. rdflib's build doesn't build the types, I could create a PR in rdflib to modify the build script. (maybe I should do that instead) but for now i just added a special step to run build:types for rdflib.

The intention behind this PR is that: I think someone should be able to clone the repo, run setup and watch-pivot and have everything work.