### PR TITLE
base-ref = staging then skip

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Check prerelease publishability
         id: check
         env:
-          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          # Skip publishing when PR originates from staging (will publish after merge)
-          if [ "$HEAD_REF" = "staging" ]; then
-            echo "Skipping: PR is from staging (will publish after merge)"
+          # Skip publishing when PR targets staging (publishes on merge push instead)
+          if [ "$BASE_REF" = "staging" ]; then
+            echo "Skipping: PR targets staging (will publish on merge)"
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
Simple: skip only when PR targets staging. Everything else proceeds.

```
base_ref == 'staging'  →  skip (case 2)
otherwise              →  proceed (includes staging→main, direct pushes, other PRs)
```

This works because:
- PR staging → main: `base_ref = main` → proceeds ✅
- PR anyBranch → staging: `base_ref = staging` → skip ✅
- Direct push: `base_ref = empty` → proceeds ✅
- PR other → main: `base_ref = main` → proceeds ✅